### PR TITLE
Remove `npm test` from CI temporarily

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -28,4 +28,4 @@ jobs:
         cache: 'npm'
     - run: npm ci
     - run: npm run build --if-present
-    - run: npm test
+    # - run: npm test


### PR DESCRIPTION
To not throw error while tests do not exist