### PR TITLE
Add logic to set API proxy depending on environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 # Port to run server on (default 8000)
 PORT=
+
+# 'development' | 'production'
+REACT_ENV=

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "dotenv": "^16.3.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.15.0",
@@ -6816,11 +6817,14 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/dotenv-expand": {
@@ -14234,6 +14238,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/read-cache": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,12 +1,12 @@
 {
   "name": "nlp-app",
   "version": "0.1.0",
-  "proxy": "http://localhost:8000", 
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "dotenv": "^16.3.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.15.0",

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,0 +1,20 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+const { dotenv } = require("dotenv").config({path:'../.env'})
+
+module.exports = function(app) {
+  const port = process.env.PORT ? parseInt(process.env.PORT) : 8000;
+  console.log('[client]: Environment is:' , process.env.REACT_ENV ? process.env.REACT_ENV : 'development')
+  const target =
+    process.env.REACT_ENV == 'production'
+      ? 'https://www.google.com'      // Your production backend URL (currently not used)
+      : `http://localhost:${port}`;   // Your default development backend URL
+
+  console.log('[client]: Backend API @' , target)
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target,
+      changeOrigin: true,
+    })
+  );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sis-team-24",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "dotenv": "^16.3.1"
+      },
       "devDependencies": {
         "concurrently": "^8.2.0"
       }
@@ -149,6 +152,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   "homepage": "https://github.com/gracebilliris/SIS-Team-24#readme",
   "devDependencies": {
     "concurrently": "^8.2.0"
+  },
+  "dependencies": {
+    "dotenv": "^16.3.1"
   }
 }

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,12 +1,13 @@
 import express, { Request, Response } from "express";
 import dotenv from 'dotenv';
 
-dotenv.config();
+dotenv.config({path:'../.env'});
 
 const app = express();
-const port: number = process.env.PORT ? parseInt(process.env.PORT, 10) : 8000;
 
-app.get('/', (req: Request, res: Response) => {
+const port: number = process.env.PORT ? parseInt(process.env.PORT) : 8000;
+
+app.get('/api', (req: Request, res: Response) => {
   res.send('⚡️⚡️⚡️ Express + TypeScript Server! ⚡️⚡️⚡️');
 });
 


### PR DESCRIPTION
Fixes #15

By default, the proxy between the React App and the backend will use localhost (with whatever port is set in `.env`). If set to production (which we will need to do eventually), it will use the URL of the backend API.