### PR TITLE
Remove forced python virtual environment for setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "PROJECT: NLP",
   "scripts": {
-    "install-all": "cd client && npm install && cd ../server && ./setup.sh",
-    "server": "cd server && source .venv/bin/activate && python3 src/main.py",
+    "install-all": "npm install && cd client && npm install && cd ../server && pip3 install --upgrade pip && pip3 install -r requirements.txt",
+    "server": "cd server && python3 src/main.py",
     "client": "cd client && npm start",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "build": "cd client && npm run build"

--- a/server/setup.sh
+++ b/server/setup.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# This script activates a Python virtual environment and installs dependencies for server.
-# Use the Virtual Environment when running the server by running `source .venv/bin/activate`
-
-python3 -mvenv .venv
-source .venv/bin/activate
-pip3 install -r requirements.txt

--- a/server/src/routes/summary_routes.py
+++ b/server/src/routes/summary_routes.py
@@ -4,7 +4,7 @@ from services import summary_service
 router = APIRouter()
 
 @router.post("/process")
-def process_text(input_data: dict, get_summary=Depends(summary_service.generate_summary)):
+def process_text(input_data: dict, get_summary=Depends(summary_service.get_summary)):
     """
     Process user-provided text and return a summary.
     """


### PR DESCRIPTION
Using a virtual environment should be optional and not enforced by the build scripts, especially if the build scripts use platform specific commands like `source`.

