### PR TITLE
Run CI jobs on all major branches

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -5,9 +5,9 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "development", "staging", "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "development", "staging", "main" ]
 
 jobs:
   build:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,11 +2,9 @@ name: Python Backend CI
 
 on:
   push:
-    branches:
-      - main
+    branches: [ "development", "staging", "main" ]
   pull_request:
-    branches:
-      - main
+    branches: [ "development", "staging", "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
Currently, we will just run the same action on all branches.

Eventually, we want this specific workflow.

PR to `development` -> build && run unit tests (deploy to development env? if we want a non-local development version)
PR to `staging` -> build && run e2e tests (and any other useful tests) this is like Cypress, deploy to staging env
PR to `main` -> deploy to prod env