### PR TITLE
Propogate server errors to frontend

### DIFF
--- a/server/src/routes/summary_routes.py
+++ b/server/src/routes/summary_routes.py
@@ -17,6 +17,7 @@ def process_text(input_data: InputData):
         summary = summary_service.get_summary(text)
         return {"summary": summary}
     except Exception as e:
+        # Whenever the backend sends a server error, frontend should render an appropriate error message.
         return HTTPException(status_code=500, detail="Server error: " + str(e))
 
 @router.get("/process")

--- a/server/src/services/summary_service.py
+++ b/server/src/services/summary_service.py
@@ -20,12 +20,8 @@ def get_summary(input_text:str):
     # Summary generator
     result = happy_tt1.generate_text(input_text, summary_args)
 
-    # Handle err if results are not found
-    try:
-        getattr(result, "text")
-        return result.text
-    except AttributeError:
-        return "ERROR: failed to summarise text."
+    # Return result text key, propogate error if does not exist
+    return result.text
     
 # TODO: delete after function finalisation...
 if __name__ == '__main__':


### PR DESCRIPTION
I think the current approach has a limitation in that, if the result does not have a text key, the `getSummary` function still returns a string, which will then be sent back to the front-end as if the backend process was successful.

I.e. if there is an error inside `getSummary` when calling `generate_text` such that the `text` key does not exist, we still return:

` { "summary ":  "ERROR: failed to summarise text." }` (with a 200 status code)

I think it would be better to handle any server errors in the front-end (i.e. inside the try catch in the frontend, if the status code is not 200, then display an appropriate error message (i.e. `setTextInput("Call to /api/summary/process failed.");`)

