### PR TITLE
fix: remove browser spec to run on ubuntu

### DIFF
--- a/e2e-run-tests.js
+++ b/e2e-run-tests.js
@@ -2,7 +2,6 @@ const cypress = require('cypress')
 
 cypress.run({
   reporter: 'junit',
-  browser: 'chrome',
   config: {
     baseUrl: 'http://localhost:3000'
   },


### PR DESCRIPTION
Removing browser specification runs the tests on your default browser. If you use Chrome it will still run the tests on Chrome no problem. For us Ubuntu users who just rely on Ubuntu's electron, this will allow the tests to run.