### PR TITLE
Add URL for backend when  file REACT_ENV is set to production

### DIFF
--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -6,7 +6,7 @@ module.exports = function(app) {
   console.log('[client]: Environment is:' , process.env.REACT_ENV ? process.env.REACT_ENV : 'development')
   const target =
     process.env.REACT_ENV == 'production'
-      ? 'https://a762-125-168-205-95.ngrok-free.app'      // Your production backend URL (currently not used)
+      ? 'https://goat-thankful-iguana.ngrok-free.app'      // Your production backend URL (currently not used)
       : `http://127.0.0.1:${port}`;   // Your default development backend URL
 
   console.log('[client]: Backend API @' , target)

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -6,7 +6,7 @@ module.exports = function(app) {
   console.log('[client]: Environment is:' , process.env.REACT_ENV ? process.env.REACT_ENV : 'development')
   const target =
     process.env.REACT_ENV == 'production'
-      ? 'https://www.google.com'      // Your production backend URL (currently not used)
+      ? 'https://e563-125-168-205-95.ngrok-free.app'      // Your production backend URL (currently not used)
       : `http://127.0.0.1:${port}`;   // Your default development backend URL
 
   console.log('[client]: Backend API @' , target)

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -6,7 +6,7 @@ module.exports = function(app) {
   console.log('[client]: Environment is:' , process.env.REACT_ENV ? process.env.REACT_ENV : 'development')
   const target =
     process.env.REACT_ENV == 'production'
-      ? 'https://e563-125-168-205-95.ngrok-free.app'      // Your production backend URL (currently not used)
+      ? 'https://a762-125-168-205-95.ngrok-free.app'      // Your production backend URL (currently not used)
       : `http://127.0.0.1:${port}`;   // Your default development backend URL
 
   console.log('[client]: Backend API @' , target)

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from .routes import summary_routes, sentiment_routes
 from .services import summary_service, sentiment_service
 import os
+import subprocess
 
 def load_env():
     # Get the directory where main.py is located
@@ -25,6 +26,23 @@ app.include_router(sentiment_routes.router, prefix="/api/sentiment")
 @app.get("/api")
 def read_root():
     return {"message": "⚡️⚡️⚡️ FastAPI + Python 3 Server! ⚡️⚡️⚡️"}
+
+
+# Webhook to update server whenever git remote updates.
+@app.post("/api/update")
+def update_server():
+    try:
+        # Step 1: Pull the latest code from the Git repository
+        pull_command = "git pull origin main"
+        subprocess.check_output(pull_command, shell=True)
+
+        # Step 2: Reload the server using Uvicorn
+        reload_command = "uvicorn server.src.main:app --host 0.0.0.0 --port 4200 --reload"
+        subprocess.Popen(reload_command, shell=True)
+
+        return {"message": "Server code updated and reloading initiated."}
+    except Exception as e:
+        return {"error": f"An error occurred: {str(e)}"}
 
 if __name__ == "__main__":
     import uvicorn


### PR DESCRIPTION
Setup a http server on my home machine which CURRENTLY runs on development branch (for now just as proof of concept). 

This branch will eventually be changed to `main`, so that we can always have an up to date demo for both the front/backend based on the latest version of main.

The server is hosted at https://goat-thankful-iguana.ngrok-free.app

To test this:

- Checkout the PR, change your `.env` file (or create a `.env` file from `.env.example if not done already) so `REACT_ENV` is 'production'. This should make the backend proxy change from your localhost to the hosted server URL (would actually be good if anyone could test if this works, I've only tested it from the same computer its hosted on).


