### PR TITLE
US-17: Custom word length (Backend only)

### DIFF
--- a/server/src/model/data_model.py
+++ b/server/src/model/data_model.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel
 
 class InputData(BaseModel):
     text: str
-    custom_len: int
+    summary_len_option: str # Value should either be "default", "short", or "long"

--- a/server/src/model/data_model.py
+++ b/server/src/model/data_model.py
@@ -2,3 +2,4 @@ from pydantic import BaseModel
 
 class InputData(BaseModel):
     text: str
+    custom_len: int

--- a/server/src/routes/summary_routes.py
+++ b/server/src/routes/summary_routes.py
@@ -10,11 +10,13 @@ def process_text(input_data: InputData):
     Process user-provided text and return a summary.
     """
     text = input_data.text
+    custom_len = input_data.custom_len
     if not text:
         raise HTTPException(status_code=400, detail="Text is required.")
-    
+    if not custom_len:
+        raise HTTPException(status_code=400, detail="Word_len is required. Either -1 or an integer between 50-400")
     try:
-        summary = summary_service.get_summary(text)
+        summary = summary_service.get_summary(text, custom_len)
         return {"summary": summary}
     except Exception as e:
         # Whenever the backend sends a server error, frontend should render an appropriate error message.

--- a/server/src/routes/summary_routes.py
+++ b/server/src/routes/summary_routes.py
@@ -10,13 +10,13 @@ def process_text(input_data: InputData):
     Process user-provided text and return a summary.
     """
     text = input_data.text
-    custom_len = input_data.custom_len
+    summary_len_option = input_data.summary_len_option
     if not text:
         raise HTTPException(status_code=400, detail="Text is required.")
-    if not custom_len:
-        raise HTTPException(status_code=400, detail="Word_len is required. Either -1 or an integer between 50-400")
+    if not summary_len_option:
+        raise HTTPException(status_code=400, detail="summary_len_option is required. The value is either 'short', 'long', or 'default'")
     try:
-        summary = summary_service.get_summary(text, custom_len)
+        summary = summary_service.get_summary(text, summary_len_option)
         return {"summary": summary}
     except Exception as e:
         # Whenever the backend sends a server error, frontend should render an appropriate error message.

--- a/server/src/services/summary_service.py
+++ b/server/src/services/summary_service.py
@@ -19,7 +19,7 @@ def load_model():
     load_summary_token_counter(model_name)
     print("[server] Loaded Summary token counter")
 
-def get_summary(input_text:str):
+def get_summary(input_text:str, custom_len=-1):
     """
     Generate a summary for the input text.
     """
@@ -36,16 +36,23 @@ def get_summary(input_text:str):
         text_to_analyse = extractive_summary(input_text);
         token_len = get_token_count(text_to_analyse, AnalysisKind.SUMMARY)
 
-    # Default: Produce a summary that's 25% - 50% of text_to_analyse token length
-    # Note: 
-    # - 512 tokens ~ 400 words --> 1024 tokens ~ 800 words
-    # - Maximum possible input into the summarizer is 1024 tokens, therefore the max possible summary output is 254 - 512 tokens (about 200 - 400 words)
-    # - Making the output range smaller increases the risk of the summary concluding in incomplete sentences [not good :)]
-    # - The 25% - 50% token length range allows the summariser to produce and conclude with COMPLETE sentences [very good :)] 
-    summary_len = math.floor(token_len * 0.25)
+    # Important Note / Assumption:
+    # - There's no universal conversion from "token" to "words"
+    # - 512 tokens ~ 400 words --> 1024 tokens ~ 800 words --> 1 word = 1.28 tokens
+
+    if custom_len == -1:
+        # Default: Produce a summary that's at least 25% of text_to_analyse token length
+        # Note: 
+        # - Maximum possible input into the summarizer is 1024 tokens, therefore the max possible summary output is at least 254 tokens (about 200 words)
+        min_len = token_len // 4
+    else:
+        # If custom_len DOES NOT equal -1, define min. length
+        print(f"\n[server] Taking into account of inputted custom summary length {custom_len}\n")
+        min_len = math.ceil(custom_len * 1.28) # Equate to a token value, take upper bound
 
     # Summary generator
-    result = summarizer(text_to_analyse, min_length=summary_len, max_length=(summary_len * 2))[0]
+    # - Max summary length will ALWAYS be half of the inputted token length. Suggested measure by Transformers
+    result = summarizer(text_to_analyse, min_length=min_len, max_length=(token_len // 2))[0]
 
     # Return result text key, propogate error if does not exist
     return result['summary_text']    


### PR DESCRIPTION
[Backend implementation ONLY]

After numerous research and testing, the final implementation of this feature is more of a "variable summary length" rather than a "custom word length" - I've left comments here and there throughout the commits but long story short - It's not guaranteed that a summary will be the desired word length due to token-to-word conversion; even after calculating and estimating the conversion, trying to make a summary with an exact number of words put the output at risk of concluding with an incomplete sentence (as it tries to hit the word limit). So after discussion with @srujankarthik , we've concluded to change this feature to a "choose your summary length" dropdown feature - where user's can pick from either "short", "default", or a "long" summary (as they output their respective amount - checkout the min_len and max_len for possible lengths). With this change, users are still able to  "customise" their summary word length.