### PR TITLE
Add default summary length options, use separate data class for API input

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -106,7 +106,7 @@ function Home(this: any) {
   const getSummary = async () => {
     setSubmitted(true);
     console.log("submitted: " + submitted);
-    const body = JSON.stringify({ text: inputValue });
+    const body = JSON.stringify({ text: inputValue , summary_len_option: "default"});
     await fetch("/api/summary/process", { ...postRequestOptions, body })
       .then((response) => response.json())
       .then((data) => {

--- a/server/src/model/data_model.py
+++ b/server/src/model/data_model.py
@@ -1,5 +1,14 @@
 from pydantic import BaseModel
+from enum import Enum
+
+# Defined analysis kinds for type safety
+class SummaryLengthOption(Enum):
+    SHORT = "short"
+    DEFAULT = "default"
+    LONG = "long"
 
 class InputData(BaseModel):
     text: str
-    summary_len_option: str # Value should either be "default", "short", or "long"
+
+class SummaryInputData(InputData):
+    summary_len_option: SummaryLengthOption # Value should either be "default", "short", or "long"

--- a/server/src/routes/summary_routes.py
+++ b/server/src/routes/summary_routes.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, HTTPException
-from ..model.data_model import InputData
+from ..model.data_model import SummaryInputData
 from ..services import summary_service
 
 router = APIRouter()
 
 @router.post("/process")
-def process_text(input_data: InputData):
+def process_text(input_data: SummaryInputData):
     """
     Process user-provided text and return a summary.
     """

--- a/server/src/services/summary_service.py
+++ b/server/src/services/summary_service.py
@@ -7,6 +7,7 @@ from string import punctuation
 from collections import Counter
 from heapq import nlargest
 from .common import get_token_count, load_summary_token_counter, AnalysisKind
+from ..model.data_model import SummaryLengthOption
 
 # Load the machine learning model during app startup
 def load_model():
@@ -19,7 +20,7 @@ def load_model():
     load_summary_token_counter(model_name)
     print("[server] Loaded Summary token counter")
 
-def get_summary(input_text:str, summary_len_option="default"):
+def get_summary(input_text:str, summary_len_option=SummaryLengthOption.DEFAULT):
     """
     Generate a summary for the input text.
     """
@@ -33,7 +34,7 @@ def get_summary(input_text:str, summary_len_option="default"):
 
     # If token_len > 1024, perform extractive summary to get the most meaningful sentences
     if token_len > 1024:
-        text_to_analyse = extractive_summary(input_text);
+        text_to_analyse = extractive_summary(input_text)
         token_len = get_token_count(text_to_analyse, AnalysisKind.SUMMARY)
 
     # Reason to why we can't do (exact) custom word length summary:
@@ -41,11 +42,11 @@ def get_summary(input_text:str, summary_len_option="default"):
     #   certain that the summary will be exactly the request custom length.
     # - Increased risk of outputting a summary that concludes with an incomplete sentence
 
-    if summary_len_option == "short":
+    if summary_len_option == SummaryLengthOption.SHORT:
         # Short summary = ~12.5% of text_to_analyse token length
         min_len = token_len // 8
         max_len = token_len // 2 # It's recommended to make the max_len at least 50% = avoid outputting incomplete sentences.
-    elif summary_len_option == "long":
+    elif summary_len_option == SummaryLengthOption.LONG:
         # Long summary = ~50% of text_to_analyse token length
         min_len = token_len // 2
         max_len = (token_len // 4) * 3
@@ -121,4 +122,4 @@ if __name__ == '__main__':
     # Ensure input.txt exists in server/src for testing.
     load_model()
     with open('input.txt', 'r', errors='ignore', encoding='utf-8') as f:
-        print(get_summary(str(f.read())))
+        print(get_summary(str(f.read()), "default"))


### PR DESCRIPTION
`development` branch, summay/sentiment calls were not working for following reasons:

- InputData API model had added `summary_len_option`, which is used for input with `getSummary`, however not used with `getSentiment`. Because of this, err was thrown as `summary_len_option` was a required field that was missing when calling `getSentiment`. 

Fixed by adding separate data class for summary that extends the base InputData class.

- `getSummary` was failing as `summary_len_option` is a required field but frontend was not providing it

Fixed by hardcoding the `default` summary length in frontend for now, to be fixed later when frontend adds options for other summary lengths.