### PR TITLE
FastAPI testing summary

### DIFF
--- a/server/test/summary_inputs/400_words.py
+++ b/server/test/summary_inputs/400_words.py
@@ -1,0 +1,17 @@
+text = """Once upon a shimmering dawn in Elmridge, a quiet village nestled within emerald valleys, lived Emma, a skilled potter known for crafting exquisite, magical pottery. Emma's creations possessed a unique allure, echoing with whispers of ancient tales and secret lore held within the clay.
+
+Emma's workshop, a cozy, sun-kissed nook, buzzed with ethereal energy, and her hands danced gracefully over the wheel, conjuring vessels of unparalleled beauty. The magic wove delicate threads of resilience and love into each piece, blessing recipients with good fortune and joy.
+
+As autumn's golden tapestry unfurled across Elmridge, a sinister shadow crept into the neighboring woods, casting a pallor of misfortune and sorrow. Emma sensed the impending peril, the tremors vibrating through the earth and settling into her soul, urging her into action.
+
+Armed with her enchanted pottery, Emma ventured into the murkiness, the dense canopy swallowing the daylight, leaving only slivers of silver moonlight to guide her. Every step sank into the soft, whispering earth, reverberating with the silent cries of the ancient trees ensnared by the encroaching darkness.
+
+In the heart of the woods, Emma encountered the shadow, a manifestation of pure malice feeding off the pain and despair of the world. It sneered, its formless face contorting into a grotesque smile, confident in its impending victory over the fragile, pulsating heart of the forest.
+
+Emma held her creations aloft, the pottery glowing with a gentle, radiant light, pulsing in tandem with the heartbeat of the earth beneath. As she whispered an ancient incantation, the light intensified, weaving through the twisted branches and piercing the suffocating shadow.
+
+With a deafening roar, the shadow recoiled, its form disintegrating under the relentless assault of love and hope embodied within Emma's pottery. As the first rays of dawn pierced the horizon, bathing the forest in a soft, golden hue, the shadow dissipated entirely, leaving behind only the whispering trees and the echoing laughter of the relieved earth.
+
+Emma returned to Elmridge, her heart light and her spirit buoyant. Her magical pottery, now infused with the indomitable strength of the ancient woods and the pure essence of dawn, became legendary, coveted by kings and peasants alike for their power and beauty.
+
+Years rolled by, and the tale of the potter who conquered darkness with her magical creations became a beloved story, whispered through the winds and sung by the bubbling brooks, inspiring hope and courage in the hearts of all who heard it."""

--- a/server/test/summary_inputs/long_len.py
+++ b/server/test/summary_inputs/long_len.py
@@ -1,0 +1,29 @@
+# 1000 words from ChatGPT
+
+text = """In the magical realm of Eldertown, nestled within the arms of ancient, towering mountains, there lived a spirited young girl named Elara. With sparkling eyes mirroring the clear azure sky, she roamed the emerald meadows filled with golden blossoms, her laughter echoing through the air, creating symphonies with the whispering winds.
+
+On one such adventurous day, beneath a sky painted with the brilliant hues of twilight, Elara stumbled upon a stone unlike any other. It was a crystal, translucent and delicate, yet it held within it a luminescent glow, pulsating softly like the heartbeat of the earth itself.
+
+This magical stone was no ordinary relic; it whispered tales, stories spun from the fabric of time itself, weaving narratives of ancient valor and undying love, tales of creatures ethereal and lands beyond imagination. Each whisper seemed to dance through the air, casting a spell of joy and enlightenment upon all who listened.
+
+Word of the whispering stone spread through Eldertown, bringing forth a surge of visitors, eager to witness its magic. The village transformed, its aura shimmering with unseen energy, and the air resonated with the subtle hum of the stone’s endless stories.
+
+However, beneath the tapestry of night, where shadows cast their silent, ominous dance, there stirred a darkness envious of the light and joy within Eldertown. With each whisper of the stone, the shadows grew restless, eventually mustering enough strength to launch an assault upon the enchanted hamlet.
+
+The night was darker than usual, with the sky devoid of its stellar companions, and the air thick with impending doom. Shadows, like tendrils of despair, began to creep into Eldertown, attempting to extinguish its vibrancy and silence the whispering stone forever.
+
+Elara, sensing the peril, clasped the magical crystal within her tender hands, feeling its warmth and ancient power coursing through her veins. With determination lighting up her eyes, she whispered back to the stone, recounting tales of hope, of resilience in the face of insurmountable odds, and of light piercing through the veil of darkness.
+
+The stone listened, absorbing Elara's whispered tales, its glow intensifying until it mirrored the brilliance of a thousand suns. The shadows recoiled, unable to withstand the radiant energy emanating from the ancient relic and the pure-hearted girl who wielded it.
+
+As Elara continued, the whispering stone cast its light further, illuminating each corner of Eldertown, dispelling the shadows and revealing the hidden beauty within the darkness. The night itself seemed to retreat, making way for the first rays of dawn, which painted the sky with strokes of gold and crimson.
+
+With the break of dawn, Eldertown was bathed in a light more glorious than ever before, its beauty enhanced by the triumph over darkness. The whispering stone, now silent, had expended its ancient magic but had imparted its tales to Elara, who became the new storyteller of Eldertown.
+
+Years rolled by, with seasons weaving their cycle of change, yet the tale of the whispering stone and the girl who defeated the night remained etched within the annals of Eldertown’s history. Elara grew older, her hair mirroring the silver glow of the moon, but her eyes retained their sparkle, reflecting the wisdom and stories she now held within.
+
+Each evening, as twilight cast its enchanting spell, people would gather around Elara, their eyes filled with anticipation. And with a smile playing upon her lips, she would begin to whisper, her voice weaving through the air, creating tapestries of tales magical and profound, continuing the legacy of the whispering stone.
+
+As the final words of her tales fell upon the ears of enchanted listeners, the night sky above would shimmer with renewed brilliance, with each star twinkling like a crystal, listening and echoing the tales whispered through the winds of Eldertown, carrying them across time and space, to lands far and unknown.
+
+Thus, the tales of Eldertown, of a magical stone and a girl with eyes like the sky, traveled through whispers and winds, finding their way into the hearts and souls of those who believed in magic, hope, and the eternal dance of light and shadow within the canvas of the universe. Each whisper carried the promise of dawn breaking through the night, of joy piercing through sorrow, and of love, eternal and unyielding, echoing through the corridors of time, weaving a story that was as ancient as it was timeless."""

--- a/server/test/summary_inputs/medium_len.py
+++ b/server/test/summary_inputs/medium_len.py
@@ -1,3 +1,5 @@
+# 400 words from ChatGPT
+
 text = """Once upon a shimmering dawn in Elmridge, a quiet village nestled within emerald valleys, lived Emma, a skilled potter known for crafting exquisite, magical pottery. Emma's creations possessed a unique allure, echoing with whispers of ancient tales and secret lore held within the clay.
 
 Emma's workshop, a cozy, sun-kissed nook, buzzed with ethereal energy, and her hands danced gracefully over the wheel, conjuring vessels of unparalleled beauty. The magic wove delicate threads of resilience and love into each piece, blessing recipients with good fortune and joy.

--- a/server/test/summary_inputs/short_len.py
+++ b/server/test/summary_inputs/short_len.py
@@ -1,0 +1,3 @@
+# 100 words from ChatGPT
+
+text = """In the mystical village of Eldertown, young Elara discovered a magical, whispering stone. The ancient, translucent crystal glowed gently, holding within it the wisdom and tales of yore. With each whisper, it dispelled sadness and showered abundant joy upon the enchanted hamlet. One ominous night, shadows attempted to engulf Eldertown, erasing its light and cheer. Elara, holding the magical stone aloft, whispered back stories of hope and valor. The shadows recoiled, defeated by the radiant energy emanating from the tales. Dawn broke, with Eldertown basking in renewed glory, and Elara’s whispering stone continuing its silent, eternal storytelling."""

--- a/server/test_route.py
+++ b/server/test_route.py
@@ -10,10 +10,8 @@ from src.main import app
 @pytest.fixture(scope="module")
 def client():
     # "with" will cause event handlers ('startup' to load models) to run in the tests
-    print("here")
     with TestClient(app) as c:
         yield c
-    print("hello")
 
 # Define tests here
 
@@ -40,5 +38,75 @@ def test_fetch_emotion(client):
 # TODO: sentiment testing
 # def test_fetch_sentiment(client):
 
-# TODO: summary testing
-# def test_fetch_summary(client):
+# Medium length input (400 words) - tests the basic API call works, and we get a response that 'summarises', i.e. shorter than the input.
+def test_fetch_summary_input_medium(client):
+    from src.model.data_model import SummaryLengthOption
+    from test.summary_inputs.medium_len import text
+
+    # Define the input data for testing
+    input_data = {
+        "text": text,
+        "summary_len_option": SummaryLengthOption.DEFAULT.value
+        }
+
+    # Test case for a successful POST request to /api/summary/process
+    response = client.post("/api/summary/process", json=input_data)
+
+    # Assert the response status code is 200 OK (or the desired status code)
+    assert response.status_code == 200
+
+    # Assert the response has a summary component
+    assert 'summary' in response.json()
+
+    # Assert the summary length is shorter than the input (can probably refine to a specific ratio, but hard based on tokens)
+    assert len(response.json()['summary']) < 0.8 * len(text)
+
+
+# Short length input (100 words) - tests the basic API call works, and we get a response that 'summarises', i.e. shorter than the input.
+def test_fetch_summary_input_short(client):
+    from src.model.data_model import SummaryLengthOption
+    from test.summary_inputs.short_len import text
+
+    # Define the input data for testing
+    input_data = {
+        "text": text,
+        "summary_len_option": SummaryLengthOption.DEFAULT.value
+        }
+
+    # Test case for a successful POST request to /api/summary/process
+    response = client.post("/api/summary/process", json=input_data)
+
+    # Assert the response status code is 200 OK (or the desired status code)
+    assert response.status_code == 200
+
+    # Assert the response has a summary component
+    assert 'summary' in response.json()
+
+    # Assert the summary length is shorter than the input (can probably refine to a specific ratio, but hard based on tokens)
+    assert len(response.json()['summary']) < 0.8 * len(text)
+
+
+# Medium length input (1000 words) - tests the basic API call works, and we get a response that 'summarises', i.e. shorter than the input.
+def test_fetch_summary_input_long(client):
+    from src.model.data_model import SummaryLengthOption
+    from test.summary_inputs.long_len import text
+
+    # Define the input data for testing
+    input_data = {
+        "text": text,
+        "summary_len_option": SummaryLengthOption.DEFAULT.value
+        }
+
+    # Test case for a successful POST request to /api/summary/process
+    response = client.post("/api/summary/process", json=input_data)
+
+    # Assert the response status code is 200 OK (or the desired status code)
+    assert response.status_code == 200
+
+    # Assert the response has a summary component
+    assert 'summary' in response.json()
+
+    # Assert the summary length is shorter than the input (can probably refine to a specific ratio, but hard based on tokens)
+    assert len(response.json()['summary']) < 0.8 * len(text)
+
+# TODO: Add futher tests for summary (i.e. performance testing, testing length ratios, testing summary length options, testing accuracy or expected outcomes)

--- a/server/test_route.py
+++ b/server/test_route.py
@@ -10,8 +10,10 @@ from src.main import app
 @pytest.fixture(scope="module")
 def client():
     # "with" will cause event handlers ('startup' to load models) to run in the tests
+    print("here")
     with TestClient(app) as c:
         yield c
+    print("hello")
 
 # Define tests here
 

--- a/server/test_route.py
+++ b/server/test_route.py
@@ -38,9 +38,10 @@ def test_fetch_emotion(client):
 # TODO: sentiment testing
 # def test_fetch_sentiment(client):
 
-# Medium length input (400 words) - tests the basic API call works, and we get a response that 'summarises', i.e. shorter than the input.
+# Medium length input (400 words) - tests the basic API call works, and we get a response length within the defined bounds.
 def test_fetch_summary_input_medium(client):
     from src.model.data_model import SummaryLengthOption
+    from src.services.common import get_token_count, AnalysisKind
     from test.summary_inputs.medium_len import text
 
     # Define the input data for testing
@@ -58,13 +59,18 @@ def test_fetch_summary_input_medium(client):
     # Assert the response has a summary component
     assert 'summary' in response.json()
 
-    # Assert the summary length is shorter than the input (can probably refine to a specific ratio, but hard based on tokens)
-    assert len(response.json()['summary']) < 0.8 * len(text)
+    # Get the token counts
+    num_input_tokens = get_token_count(text, AnalysisKind.SUMMARY)
+    num_output_tokens = get_token_count(response.json()['summary'], AnalysisKind.SUMMARY)
+
+    # Assert the summary length is within min/max token range for summary_len_option
+    assert num_output_tokens > num_input_tokens // 4 and num_output_tokens < num_input_tokens // 2
 
 
-# Short length input (100 words) - tests the basic API call works, and we get a response that 'summarises', i.e. shorter than the input.
+# Short length input (100 words) - tests the basic API call works, and we get a response length within the defined bounds.
 def test_fetch_summary_input_short(client):
     from src.model.data_model import SummaryLengthOption
+    from src.services.common import get_token_count, AnalysisKind
     from test.summary_inputs.short_len import text
 
     # Define the input data for testing
@@ -82,13 +88,18 @@ def test_fetch_summary_input_short(client):
     # Assert the response has a summary component
     assert 'summary' in response.json()
 
-    # Assert the summary length is shorter than the input (can probably refine to a specific ratio, but hard based on tokens)
-    assert len(response.json()['summary']) < 0.8 * len(text)
+    # Get the token counts
+    num_input_tokens = get_token_count(text, AnalysisKind.SUMMARY)
+    num_output_tokens = get_token_count(response.json()['summary'], AnalysisKind.SUMMARY)
+
+    # Assert the summary length is within min/max token range for summary_len_option
+    assert num_output_tokens > num_input_tokens // 4 and num_output_tokens < num_input_tokens // 2
 
 
-# Medium length input (1000 words) - tests the basic API call works, and we get a response that 'summarises', i.e. shorter than the input.
+# Long length input (1000 words) - tests the basic API call works, and we get a response length within the defined bounds.
 def test_fetch_summary_input_long(client):
     from src.model.data_model import SummaryLengthOption
+    from src.services.common import get_token_count, AnalysisKind
     from test.summary_inputs.long_len import text
 
     # Define the input data for testing
@@ -106,7 +117,11 @@ def test_fetch_summary_input_long(client):
     # Assert the response has a summary component
     assert 'summary' in response.json()
 
-    # Assert the summary length is shorter than the input (can probably refine to a specific ratio, but hard based on tokens)
-    assert len(response.json()['summary']) < 0.8 * len(text)
+    # Get the token counts
+    num_input_tokens = get_token_count(text, AnalysisKind.SUMMARY)
+    num_output_tokens = get_token_count(response.json()['summary'], AnalysisKind.SUMMARY)
+
+    # Assert the summary length is within min/max token range for summary_len_option
+    assert num_output_tokens > num_input_tokens // 4 and num_output_tokens < num_input_tokens // 2
 
 # TODO: Add futher tests for summary (i.e. performance testing, testing length ratios, testing summary length options, testing accuracy or expected outcomes)


### PR DESCRIPTION
Semi-fixes #129 (there is more work to be done for full test coverage)

Tests the summary API with basic inputs (short, medium, long), using the `default` summary length option.

Simply tests the API call is successful, and returns a JSON object with summary key, which is text that has a length of at most 80% the length of original input. 

Additional tests in future can test accuracy, performance (timing), testing length when the `summary_len_option` varies, etc.