### PR TITLE
Fix sentiment API issue when token len > 512

### DIFF
--- a/server/src/services/sentiment_service.py
+++ b/server/src/services/sentiment_service.py
@@ -52,7 +52,7 @@ def get_sentiment(input_text:str):
         # Load get_summary() only when this condition is met.
         from .summary_service import get_summary
         # TODO: currently get_summary() is set to return a summary of 100 words - change following implementation upon related project progress.
-        text_to_analyse = get_summary(input_text)
+        text_to_analyse = get_summary(input_text)['summary']
 
     # Both analysers return an arr - take first index.
     # Execute sentiment analyser.   


### PR DESCRIPTION
Fixes #193 

When input > 512 tokens, sentiment had to perform extractive summary to reduce the input down to a size that the sentiment model can handle. During this function call, getSummary returns a dict with `summary` key, when sentiment analyser expectes a raw string. Fixed by setting `text_to_analyse = getSummary(input)['summary']`